### PR TITLE
Changed archetypes template to open resources links in a new tab

### DIFF
--- a/resources/templates/archetypes/archetype.md.j2
+++ b/resources/templates/archetypes/archetype.md.j2
@@ -67,6 +67,6 @@
 | 🗣️ | Name | Author | Date |
 | -- | ---- | ------ | ---- |
 {% for resource in resources -%}
-| {{ resource.language }} | [{{ resource.name }}]({{ resource.url }}) | {{ resource.author }} | {{ "%-12s" % resource.date }} |
+| {{ resource.language }} | <a target="_blank" href="{{ resource.url }}">{{ resource.name }}</a> | {{ resource.author }} | {{ "%-12s" % resource.date }} |
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
@ShadowTemplate I haven't found any test to run, so you may want to double check this.