### PR TITLE
wip: archetype centroid

### DIFF
--- a/pauperformance_bot/center_soul/main.py
+++ b/pauperformance_bot/center_soul/main.py
@@ -1,0 +1,227 @@
+import os
+import re
+from copy import copy
+from os import path
+from statistics import mean, stdev, variance
+from typing import Dict, List, Optional, Tuple
+
+import jsonpickle
+
+from pauperformance_bot.constant.pauperformance.academy import AcademyFileSystem
+from pauperformance_bot.entity.api.deck import Deck
+from pauperformance_bot.entity.deck.playable import (
+    PlayableDeck,
+    parse_playable_deck_from_lines,
+)
+from pauperformance_bot.service.academy.academy import AcademyService
+from pauperformance_bot.service.pauperformance.archive.local import LocalArchiveService
+from pauperformance_bot.service.pauperformance.pauperformance import (
+    PauperformanceService,
+)
+from pauperformance_bot.service.pauperformance.storage.local import LocalStorageService
+from pauperformance_bot.util.log import get_application_logger
+from pauperformance_bot.util.path import posix_path
+
+logger = get_application_logger()
+
+
+def load_deck(playable_deck_txt) -> Optional[PlayableDeck]:
+    playable_deck = None
+    try:
+        with open(playable_deck_txt) as playable_f:
+            lines = [line.strip() for line in playable_f.readlines()]
+            playable_deck = parse_playable_deck_from_lines(lines)
+    except Exception as e:
+        logger.error(f"Cannot parse {playable_deck_txt}. Error: {e}")
+    finally:
+        return playable_deck
+
+
+class AcademyAssetsService:
+    def __init__(self, academy_fs=AcademyFileSystem()):
+        if not isinstance(academy_fs, AcademyFileSystem):
+            raise ValueError(f"{type(academy_fs)} is not AcademyFileSystem")
+        self._academy_fs = academy_fs
+
+    def get_playable_decks(self, archetype) -> List[PlayableDeck]:
+        deck_dir = posix_path(self._academy_fs.ASSETS_DATA_INTEL_DECK_DIR, archetype)
+        if not path.exists(deck_dir):
+            logger.error(
+                f"No dir for archetype {archetype} found in "
+                + f"{self._academy_fs.ASSETS_DATA_INTEL_DECK_DIR}"
+            )
+            return []
+        playable_decks, missing = self.__load_all(deck_dir)
+        if missing:
+            logger.warning(
+                f"{len(missing)} decks not found in "
+                + f"{self._academy_fs.ASSETS_DATA_DECK_MTGGOLDFISH_TOURNAMENT_DIR} "
+                + f"for archetype {archetype}: {missing}"
+            )
+        return playable_decks
+
+    def __load_all(self, deck_dir):
+        missing = []
+        playable_decks = []
+        for deck_file in os.listdir(deck_dir):
+            with open(posix_path(deck_dir, deck_file)) as deck_f:
+                deck: Deck = jsonpickle.decode(deck_f.read(), safe=True)
+                deck_id = re.sub(r"^.*/", "", deck.url)
+            playable_deck_txt = posix_path(
+                self._academy_fs.ASSETS_DATA_DECK_MTGGOLDFISH_TOURNAMENT_DIR,
+                f"{deck_id}.txt",
+            )
+            if not path.exists(playable_deck_txt):
+                missing.append(deck_id)
+                continue
+            playable = load_deck(playable_deck_txt)
+            if playable:
+                playable_decks.append(playable)
+        return playable_decks, missing
+
+
+class ArchetypeMeta:
+    def __init__(
+        self,
+        name: str,
+        playable_decks: List[PlayableDeck],
+        cards: Dict[str, Dict[str, int]],
+    ):
+        self.name = name
+        self._playable_decks = playable_decks
+        self._cards = cards
+
+    @property
+    def nr_decks(self) -> int:
+        return len(self._playable_decks)
+
+    @property
+    def cards(self) -> List[str]:
+        return list(self._cards.keys())
+
+    @property
+    def most_played(self) -> str:
+        return max(self._cards.items(), key=lambda x: x[1]["count"])
+
+    @property
+    def total_played(self) -> int:
+        return sum(card["count"] for _, card in self._cards.items())
+
+    @property
+    def deck_frequencies(self) -> List[Tuple[str, float]]:
+        return sorted(
+            list(
+                map(
+                    lambda card: (card[0], card[1]["decks"] / self.nr_decks),
+                    self._cards.items(),
+                )
+            ),
+            key=lambda x: x[1],
+            reverse=True,
+        )
+
+    @property
+    def card_frequencies(self) -> List[Tuple[str, float]]:
+        total = self.total_played
+        return sorted(
+            list(
+                map(
+                    lambda card: (card[0], card[1]["count"] / total),
+                    self._cards.items(),
+                )
+            ),
+            key=lambda x: x[1],
+            reverse=True,
+        )
+
+
+class ArchetypeMetaFactory:
+    def __init__(self, academy: AcademyService, assets_service: AcademyAssetsService):
+        if not isinstance(academy, AcademyService):
+            raise ValueError(f"{type(academy)} is not an AcademyService")
+        if not isinstance(assets_service, AcademyAssetsService):
+            raise ValueError(f"{type(assets_service)} is not an AcademyAssetsService")
+        self._academy = academy
+        self._assets_service = assets_service
+
+    def build_meta_for(self, archetype: str) -> ArchetypeMeta:
+        playable_decks = self._assets_service.get_playable_decks(archetype)
+        logger.debug(f"Found {len(playable_decks)} decks for {archetype}")
+        cards = {}
+        for _, pd in enumerate(playable_decks):
+            for card in pd.sideboard + pd.mainboard:
+                sf_card = self._academy.scryfall.get_card_named(
+                    card.card_name, fuzzy=True
+                )
+                if not sf_card:
+                    logger.warning(f"Cannot fetch {card.card_name} from Scryfall")
+                elif "land" in sf_card["type_line"].lower():
+                    logger.debug(f"Skipping land {card.card_name}")
+                    continue
+                if card.card_name not in cards:
+                    cards[card.card_name] = {"decks": 0, "count": 0}
+                cards[card.card_name]["decks"] += 1
+                cards[card.card_name]["count"] += card.quantity
+        return ArchetypeMeta(archetype, playable_decks, cards)
+
+
+class ArchetypeCentroid:
+    def __init__(self, meta: ArchetypeMeta):
+        if not meta or not isinstance(meta, ArchetypeMeta):
+            raise ValueError(f"{type(meta)} is not ArchetypeMeta")
+        self._cards = sorted(list(filter(lambda f: f[1] >= 0.9, meta.deck_frequencies)))
+
+    @property
+    def cards(self) -> List[Tuple[str, float]]:
+        return copy(self._cards)
+
+    def __repr__(self):
+        return f"Nr. Cards: {len(self._cards)} Cards: {self._cards}"
+
+    def __str__(self):
+        return f"{self._cards}"
+
+
+def test_outputs(am: ArchetypeMeta):
+    logger.info(am.cards)
+    logger.info(f"nr. decks: {am.nr_decks} max: {am.most_played}")
+    dfq = am.deck_frequencies
+    cfq = am.card_frequencies
+    logger.info("# DECKS")
+    logger.info(f"max deck freq.: {dfq[0]}")
+    centroid = sorted(list(map(lambda f: f[0], filter(lambda f: f[1] >= 0.9, dfq))))
+    logger.info(f"centroid(decks): {centroid}")
+    deck_freqs = [f[1] for f in dfq]
+    mean_deck_freq = mean(deck_freqs)
+    logger.info(f"stdev: {stdev(deck_freqs)}  variance: {variance(deck_freqs)}")
+    logger.info(f"mean {mean_deck_freq}")
+    logger.info("# CARDS")
+    logger.info(f"max card freq {cfq[0]}")
+    centroid = sorted(list(map(lambda f: f[0], filter(lambda f: f[1] >= 0.07, cfq))))
+    logger.info(f"centroid(cards): {centroid}")
+    card_freqs = [f[1] for f in cfq]
+    mean_card_freq = mean(card_freqs)
+    logger.info(f"stdev: {stdev(card_freqs)} variance: {variance(card_freqs)}")
+    logger.info(f"mean {mean_card_freq}")
+    s_card_fqs = sorted(list(map(lambda f: f[0], filter(
+            lambda f: f[1] >= mean_card_freq + stdev(card_freqs), cfq),)))
+    logger.info(f"staples(cards): {s_card_fqs}")
+
+
+def main():
+    storage = LocalStorageService()
+    archive = LocalArchiveService()
+    pauperformance = PauperformanceService(storage, archive)
+    academy = AcademyService(pauperformance)
+    archetype = "Burn"
+    # index = academy.set_index
+    # logger.info(index)
+    aas = AcademyAssetsService()
+    am = ArchetypeMetaFactory(academy, aas).build_meta_for(archetype)
+    centroid = ArchetypeCentroid(am)
+    logger.info(centroid.__repr__())
+
+
+if __name__ == "__main__":
+    # TODO remove main
+    main()

--- a/pauperformance_bot/service/mtg/scryfall.py
+++ b/pauperformance_bot/service/mtg/scryfall.py
@@ -31,6 +31,7 @@ class ScryfallService:
         self,
         exact_card_name,
         cards_cache_dir=SCRYFALL_CARDS_CACHE_DIR,
+        fuzzy=False,
     ):
         try:
             with open(
@@ -44,7 +45,10 @@ class ScryfallService:
             logger.debug(f"No cache found for card {exact_card_name}.")
             url = f"{self.endpoint}/cards/named"
             method = requests.get
-            params = {"exact": exact_card_name}
+            if fuzzy:
+                params = {"fuzzy": exact_card_name}
+            else:
+                params = {"exact": exact_card_name}
             method = partial(method, params=params)
             try:
                 response = execute_http_request(method, url)


### PR DESCRIPTION
rebase original [PR](https://github.com/Pauperformance/pauperformance-bot/pull/78)

First working solution for #75 
I've tried it with 3 archetypes with different settings (see the `main` fun in the [main.py](https://github.com/Pauperformance/pauperformance-bot/blob/feature/archetype-centroid/pauperformance_bot/center_soul/main.py)
Here are the results:
```
# BURN
## DECKS
nr. decks: 1404 max: ('Lightning Bolt', {'decks': 1404, 'count': 5614})
max deck freq.: ('Searing Blaze', 1.1025641025641026)
staples(decks): ['Chain Lightning', 'Fireblast', 'Lava Spike', 'Lightning Bolt', 'Needle Drop', 'Rift Bolt', 'Searing Blaze']
stdev: 0.26507620094684603 mean 0.11472955268575706 variance: 0.0702653923084127
staples(decks): ['Chain Lightning', 'Curse of the Pierced Heart', 'Electrickery', 'Fireblast', 'Firebrand Archer', 'Flame Rift', 'Flaring Pain', 'Ghitu Lavarunner', 'Incinerate', 'Keldon Marauders', 'Kiln Fiend', 'Lava Spike', 'Lightning Bolt', 'Martyr of Ashes', 'Molten Rain', 'Needle Drop', 'Pyroblast', 'Rift Bolt', 'Searing Blaze', 'Shard Volley', 'Skewer the Critics', 'Staggershock', 'Thermo-Alchemist']
## CARDS
max card freq ('Lightning Bolt', 0.07511774780560908)
staples(cards): ['Chain Lightning', 'Fireblast', 'Lava Spike', 'Lightning Bolt', 'Rift Bolt', 'Searing Blaze']
stdev: 0.01823388787767337 mean 0.0072992700729927005 variance: 0.00033247466713556384
staples(cards): ['Chain Lightning', 'Curse of the Pierced Heart', 'Electrickery', 'Fireblast', 'Flame Rift', 'Flaring Pain', 'Ghitu Lavarunner', 'Goblin Fireslinger', 'Incinerate', 'Keldon Marauders', 'Kiln Fiend', 'Lava Spike', 'Lightning Bolt', 'Martyr of Ashes', 'Molten Rain', 'Needle Drop', 'Pyroblast', 'Rift Bolt', 'Searing Blaze', 'Shard Volley', 'Skewer the Critics', 'Staggershock', 'Thermo-Alchemist']

# Stompy
## DECKS
max deck freq.: ('Vines of Vastwood', 1.0437893531768747) max card freq ('Rancor', 0.07080759260296716)
staples(decks): ['Gleeful Sabotage', 'Hunger of the Howlpack', 'Nettle Sentinel', 'Quirion Ranger', 'Rancor', 'Skarrgan Pit-Skulk', 'Vines of Vastwood']
stdev: 0.24695354881615056 mean 0.10891476610506134 variance: 0.06098605527289086
staples(decks): ['Epic Confrontation', 'Fog', 'Gather Courage', 'Gleeful Sabotage', 'Groundswell', 'Hornet Sting', 'Hunger of the Howlpack', 'Nest Invader', 'Nettle Sentinel', 'Quirion Ranger', 'Rancor', 'River Boa', 'Scattershot Archer', "Shinen of Life's Roar", 'Silhana Ledgewalker', 'Skarrgan Pit-Skulk', 'Vault Skirge', 'Vines of Vastwood', 'Young Wolf']
## CARDS
staples(cards): ['Nettle Sentinel', 'Rancor']
stdev: 0.015191058558437394 mean 0.006024096385542169 variance: 0.00023076826012587398
staples(cards): ['Burning-Tree Emissary', 'Gather Courage', 'Gleeful Sabotage', 'Groundswell', 'Hornet Sting', 'Hunger of the Howlpack', 'Nest Invader', 'Nettle Sentinel', 'Quirion Ranger', 'Rancor', 'River Boa', 'Scattershot Archer', 'Silhana Ledgewalker', 'Skarrgan Pit-Skulk', 'Vault Skirge', 'Vines of Vastwood', 'Young Wolf']

# Izzet Faeries
## DECKS
max deck freq.: ('Skred', 1.0330528846153846)
staples(decks): ['Augur of Bolas', 'Brainstorm', 'Counterspell', 'Lightning Bolt', 'Ninja of the Deep Hours', 'Preordain', 'Skred', 'Spellstutter Sprite']
stdev: 0.24274328967689218 mean 0.10053095261697066 variance: 0.05892430468315959
staples(decks): ['Augur of Bolas', 'Brainstorm', 'Counterspell', 'Delver of Secrets', 'Dispel', 'Echoing Truth', 'Electrickery', 'Faerie Miscreant', 'Faerie Seer', 'Gorilla Shaman', 'Gush', 'Hydroblast', 'Lightning Bolt', 'Ninja of the Deep Hours', 'Ponder', 'Preordain', 'Pyroblast', 'Relic of Progenitus', 'Skred', 'Spellstutter Sprite', 'Stormbound Geist']
## CARDS
max card freq ('Spellstutter Sprite', 0.0729338911762421)
staples(cards): ['Counterspell', 'Ninja of the Deep Hours', 'Spellstutter Sprite']
stdev: 0.014502144957401469 mean 0.005154639175257732 variance: 0.00021031220836548482
staples(cards): ['Augur of Bolas', 'Brainstorm', 'Counterspell', 'Delver of Secrets', 'Electrickery', 'Faerie Miscreant', 'Faerie Seer', 'Gorilla Shaman', 'Hydroblast', 'Lightning Bolt', 'Ninja of the Deep Hours', 'Ponder', 'Preordain', 'Pyroblast', 'Skred', 'Spellstutter Sprite']

```
I think the second line after `## DECKS` is the most solid (corresponds to line 158 in the [main.py](https://github.com/Pauperformance/pauperformance-bot/blob/feature/archetype-centroid/pauperformance_bot/center_soul/main.py)) because the data is more sparse (stdev is higher). This is ignoring the amount of copies played. It's only counting the nr. of decks that contain a certain card, so it's basically the frequency of use in tournaments. 

I did not implement the filter for the set index yet.